### PR TITLE
Replace capital L with lowercase l

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -4,7 +4,7 @@
 require 'wikidata/fetcher'
 
 names = EveryPolitician::Wikidata.morph_wikinames(source: 'tmtmtmtm/italy-legislature-XVII-wikipedia', column: 'wikiname')
-by_cat = WikiData::Category.new( 'Categoria:Deputati della XVII Legislatura della Repubblica Italiana', 'it').member_titles
+by_cat = WikiData::Category.new( 'Categoria:Deputati della XVII legislatura della Repubblica Italiana', 'it').member_titles
 
 abort "No members in category" if by_cat.empty?
 


### PR DESCRIPTION
Scraper was aborting with the message "No members in category".

Changing the 'L' in 'Legislatura' to l (th string argument in
WikiData::Category.new) fixes this.

Step towards fixing: https://github.com/everypolitician/everypolitician-data/pull/18196

@tmtmtmtm Could you re-run the scraper once merged? https://morph.io/tmtmtmtm/italy-legislature-XVII-wikidata
